### PR TITLE
Fix FS caching issues in the metastore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
     <flatbuffers.version>1.2.0-3f79e055</flatbuffers.version>
     <guava.version>19.0</guava.version>
     <groovy.version>2.4.11</groovy.version>
-    <hadoop.version>2.8.2.8-SNAPSHOT</hadoop.version>
+    <hadoop.version>2.8.2.8</hadoop.version>
     <h2database.version>1.3.166</h2database.version>
     <hadoop.bin.path>${basedir}/${hive.path.to.root}/testutils/hadoop</hadoop.bin.path>
     <hamcrest.version>1.3</hamcrest.version>

--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
@@ -109,9 +109,10 @@ public class Warehouse {
    */
   public static FileSystem getFs(Path f, Configuration conf) throws MetaException {
     try {
-      //TODO: tell hdfs client where the certificates are
-
-      return f.getFileSystem(conf);
+      // Hops changes the configuration object and adds the TLS configuration settings
+      // Conf is a shared object for all the clients. That's why we need to clone it
+      // before calling the getFileSystem.
+      return f.getFileSystem(new Configuration(conf));
     } catch (IOException e) {
       MetaStoreUtils.logAndThrowMetaException(e);
     }
@@ -650,7 +651,10 @@ public class Warehouse {
       throws MetaException {
     try {
       Path path = new Path(location);
-      FileSystem fileSys = path.getFileSystem(conf);
+      // Hops changes the configuration object and adds the TLS configuration settings
+      // Conf is a shared object for all the clients. That's why we need to clone it
+      // before calling the getFileSystem.
+      FileSystem fileSys = path.getFileSystem(new Configuration(conf));
       return FileUtils.getFileStatusRecurse(path, -1, fileSys);
     } catch (IOException ioe) {
       MetaStoreUtils.logAndThrowMetaException(ioe);
@@ -668,7 +672,10 @@ public class Warehouse {
       throws MetaException {
     Path tablePath = getDnsPath(new Path(table.getSd().getLocation()));
     try {
-      FileSystem fileSys = tablePath.getFileSystem(conf);
+      // Hops changes the configuration object and adds the TLS configuration settings
+      // Conf is a shared object for all the clients. That's why we need to clone it
+      // before calling the getFileSystem.
+      FileSystem fileSys = tablePath.getFileSystem(new Configuration(conf));
       return FileUtils.getFileStatusRecurse(tablePath, -1, fileSys);
     } catch (IOException ioe) {
       MetaStoreUtils.logAndThrowMetaException(ioe);


### PR DESCRIPTION
The Warehouse has a single configuration object. The configuration is
passed down to the FS when doing FS operations. Unfortunately, the
HopsSSLSocket factory changes the configuration and adds client
keystore/truststore information.

The keystore information is also used to get cached FS objects from the
cache. As the "root configuration" object is shared across Metastore clients
and users, this makes that in case of concurrent operations users might
get from the cache a FS object for another user. Triggering either an
authentication exception (UGI doesn't match the certificates) or a
Certificates not found exception as they might have been cleaned up upon
the right user closing the connection.

This is a temporary workaround only limited to the metastore. I believe
a proper solution is to have the HopsSSLSocket factory to clone the
configuration object before injecting user specific configurations.