### PR TITLE
Validate ssl-server.xml permissions before loading

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -4311,11 +4311,11 @@ public class HiveConf extends Configuration {
         // which is available to the daemons. As such we should avoid to print them when a user requests a property dump or
         // value for a specific field.
         + ",hops.jwt-manager.master-token"
-        + ",hops.jwt-manager.master-token-0"
-        + ",hops.jwt-manager.master-token-1"
-        + ",hops.jwt-manager.master-token-2"
-        + ",hops.jwt-manager.master-token-3"
-        + ",hops.jwt-manager.master-token-4"
+        + ",hops.jwt-manager.renew-token-0"
+        + ",hops.jwt-manager.renew-token-1"
+        + ",hops.jwt-manager.renew-token-2"
+        + ",hops.jwt-manager.renew-token-3"
+        + ",hops.jwt-manager.renew-token-4"
         // Adding the S3 credentials from Hadoop config to be hidden
         + ",fs.s3.awsAccessKeyId"
         + ",fs.s3.awsSecretAccessKey"

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -5195,10 +5195,11 @@ public class HiveConf extends Configuration {
     }
 
     // Load ssl-server.xml (in HADOOP_CONF_DIR) if we are not in the context of a client
-    String sslServerPath = get(SSLFactory.SSL_SERVER_CONF_KEY, "ssl-server.xml");
     if (!client) {
-      if (new File(sslServerPath).canRead()) {
-        addResource(sslServerPath);
+      String resource = get(SSLFactory.SSL_SERVER_CONF_KEY, "ssl-server.xml");
+      String resourcePath = ClassLoader.getSystemResource(resource).getPath();
+      if (new File(resourcePath).canRead()) {
+        addResource(resource);
       } else {
         LOG.warn("Could not load ssl-server, this is probably a client so it is fine. Continuing.");
       }

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.common.classification.InterfaceAudience;
 import org.apache.hadoop.hive.common.classification.InterfaceAudience.LimitedPrivate;
@@ -4308,6 +4307,15 @@ public class HiveConf extends Configuration {
         + "," + FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER, FileBasedKeyStoresFactory.SSL_TRUSTSTORE_RELOAD_INTERVAL_TPL_KEY)
         + "," + FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER, FileBasedKeyStoresFactory.SSL_TRUSTSTORE_TYPE_TPL_KEY)
         + "," + FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER, FileBasedKeyStoresFactory.SSL_EXCLUDE_CIPHER_LIST)
+        // these properties should not be used by Hive, that's why there is no enum. However they are in the ssl-server.xml
+        // which is available to the daemons. As such we should avoid to print them when a user requests a property dump or
+        // value for a specific field.
+        + ",hops.jwt-manager.master-token"
+        + ",hops.jwt-manager.master-token-0"
+        + ",hops.jwt-manager.master-token-1"
+        + ",hops.jwt-manager.master-token-2"
+        + ",hops.jwt-manager.master-token-3"
+        + ",hops.jwt-manager.master-token-4"
         // Adding the S3 credentials from Hadoop config to be hidden
         + ",fs.s3.awsAccessKeyId"
         + ",fs.s3.awsSecretAccessKey"
@@ -5187,8 +5195,13 @@ public class HiveConf extends Configuration {
     }
 
     // Load ssl-server.xml (in HADOOP_CONF_DIR) if we are not in the context of a client
+    String sslServerPath = get(SSLFactory.SSL_SERVER_CONF_KEY, "ssl-server.xml");
     if (!client) {
-      addResource(get(SSLFactory.SSL_SERVER_CONF_KEY, "ssl-server.xml"));
+      if (new File(sslServerPath).canRead()) {
+        addResource(sslServerPath);
+      } else {
+        LOG.warn("Could not load ssl-server, this is probably a client so it is fine. Continuing.");
+      }
     }
 
     // Overlay the values of any system properties whose names appear in the list of ConfVars

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <flatbuffers.version>1.2.0-3f79e055</flatbuffers.version>
     <guava.version>19.0</guava.version>
     <groovy.version>2.4.11</groovy.version>
-    <hadoop.version>3.2.0.0-SNAPSHOT</hadoop.version>
+    <hadoop.version>3.2.0.0-RC1</hadoop.version>
     <h2database.version>1.3.166</h2database.version>
     <hadoop.bin.path>${basedir}/${hive.path.to.root}/testutils/hadoop</hadoop.bin.path>
     <hamcrest.version>1.3</hamcrest.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -65,7 +65,7 @@
     <dropwizard-metrics-hadoop-metrics2-reporter.version>0.1.2</dropwizard-metrics-hadoop-metrics2-reporter.version>
     <dropwizard.version>3.1.0</dropwizard.version>
     <guava.version>19.0</guava.version>
-    <hadoop.version>3.2.0.0-SNAPSHOT</hadoop.version>
+    <hadoop.version>3.2.0.0-RC1</hadoop.version>
     <hikaricp.version>2.6.1</hikaricp.version>
     <jackson.version>2.9.4</jackson.version>
     <javolution.version>5.5.1</javolution.version>

--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -228,6 +228,16 @@ public class MetastoreConf {
       FileBasedKeyStoresFactory.resolvePropertyName(SSLFactory.Mode.SERVER, FileBasedKeyStoresFactory.SSL_EXCLUDE_CIPHER_LIST)
   );
 
+  // these properties should not be used by Hive, that's why there is no enum. However they are in the ssl-server.xml
+  // which is available to the daemons. As such we should avoid to print them when a user requests a property dump or
+  // value for a specific field.
+  static {
+    unprintables.add("hops.jwt-manager.master-token");
+    for (int i = 0; i < 5; i++) {
+      unprintables.add("hops.jwt-manager.master-token-" + i);
+    }
+  }
+
   public static ConfVars getMetaConf(String name) {
     return metaConfs.get(name);
   }

--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -234,7 +234,7 @@ public class MetastoreConf {
   static {
     unprintables.add("hops.jwt-manager.master-token");
     for (int i = 0; i < 5; i++) {
-      unprintables.add("hops.jwt-manager.master-token-" + i);
+      unprintables.add("hops.jwt-manager.renew-token-" + i);
     }
   }
 

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -27,7 +27,7 @@
     <commons-lang.version>2.6</commons-lang.version>
     <commons-logging.version>1.1.3</commons-logging.version>
     <guava.version>19.0</guava.version>
-    <hadoop.version>3.2.0.0-SNAPSHOT</hadoop.version>
+    <hadoop.version>3.2.0.0-RC1</hadoop.version>
     <junit.version>4.11</junit.version>
     <slf4j.version>1.7.10</slf4j.version>
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>


### PR DESCRIPTION
Hive Server and Hive Metastore rely on HiveConf object. To setup the
thrift server correctly they also need access to the ssl-server.xml.

The same configuration object is also used by the clients, which don't
have access to that file. There is already a flag to disable the
loading, however in some cases it's not possible to distinguish if the
call originates from a server or a client. As such, we add a validation
step that checks the permissions of the file before loading. If the file
cannot be read than it's skipped.

Moreover add a the JWT token properties in the ssl-server file in
the hidden list for both the Hive Server and Hive Metastore