### PR TITLE
HOPSFS-230 Bump Hops Hadoop Version to 3.2.0.16-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     <flatbuffers.version>1.9.0</flatbuffers.version>
     <guava.version>27.0-jre</guava.version>
     <groovy.version>2.4.11</groovy.version>
-    <hadoop.version>3.2.0.15-EE-RC0</hadoop.version>
+    <hadoop.version>3.2.0.16-SNAPSHOT</hadoop.version>
     <h2database.version>1.3.166</h2database.version>
     <hadoop.bin.path>${basedir}/${hive.path.to.root}/testutils/hadoop</hadoop.bin.path>
     <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
HOPSFS-230 Bump Hops Hadoop Version to 3.2.0.16-SNAPSHOT