### PR TITLE
HOPSFS-346: Introduce image build version to decouple image tags from…

### DIFF
--- a/dockerfiles/Jenkinsfile
+++ b/dockerfiles/Jenkinsfile
@@ -15,9 +15,15 @@ node("local") {
               export VERSION=\$(cat version.log)
               echo -n \$VERSION > version.log
               echo \$VERSION
+
+              mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=image.build.version | grep -Ev 'Download|INFO|WARNING' > build_version.log
+              export BUILD_VERSION=\$(cat build_version.log)
+              echo -n \$BUILD_VERSION > build_version.log
+              echo \$BUILD_VERSION
         """
-        version = readFile "${env.WORKSPACE}/version.log"
-        withEnv(["HIVE_VERSION=${version.trim()}", ]) {
+        version = readFile("${env.WORKSPACE}/version.log").trim()
+        buildVersion = readFile("${env.WORKSPACE}/build_version.log").trim()
+        withEnv(["HIVE_VERSION=${version.trim()}", "IMAGE_BUILD_VERSION=${buildVersion.trim()}"]) {
           def builder = new ImageBuilder(this)
 
           sh "printf \"user=$USERNAME\npassword=$PASSWORD\" > $WORKSPACE/dockerfiles/wgetrc"

--- a/dockerfiles/build-manifest.json
+++ b/dockerfiles/build-manifest.json
@@ -1,9 +1,10 @@
 [
     {
         "name": "hopsworks/hive",
-        "version": "env:HIVE_VERSION",
+        "version": "`printf \"%s-%s\" $HIVE_VERSION $IMAGE_BUILD_VERSION`",
         "variables": [
-          "HIVE_VERSION"
+          "HIVE_VERSION",
+          "IMAGE_BUILD_VERSION"
         ],
         "dockerFile": "dockerfiles/Dockerfile",
         "extraDockerArgs": "--secret id=wgetrc,src=wgetrc --build-arg HIVE_VERSION=${HIVE_VERSION}"

--- a/dockerfiles/docker-bake.hcl
+++ b/dockerfiles/docker-bake.hcl
@@ -26,6 +26,10 @@ variable "JIRA_TAG" {
   default = "$JIRA_TAG"
 }
 
+variable "IMAGE_BUILD_VERSION" {
+  default = "$IMAGE_BUILD_VERSION"
+}
+
 
 target "hive" {
     dockerfile = "./Dockerfile"
@@ -38,9 +42,9 @@ target "hive" {
         HIVE_TAR_NAME = "${HIVE_TAR_NAME}",
     }
     tags = [
-        "${REGISTRY}/${REGISTRY_PROJECT}/hopsworks/hive:${HIVE_VERSION}",
-        "${REGISTRY}/${REGISTRY_PROJECT}/hopsworks/hive:${HIVE_VERSION}-${COMMIT_HASH}",
-        "${REGISTRY}/${REGISTRY_PROJECT}/hopsworks/hive:${HIVE_VERSION}-${JIRA_TAG}",
+        "${REGISTRY}/${REGISTRY_PROJECT}/hopsworks/hive:${HIVE_VERSION}-${IMAGE_BUILD_VERSION}",
+        "${REGISTRY}/${REGISTRY_PROJECT}/hopsworks/hive:${HIVE_VERSION}-${IMAGE_BUILD_VERSION}-${COMMIT_HASH}",
+        "${REGISTRY}/${REGISTRY_PROJECT}/hopsworks/hive:${HIVE_VERSION}-${IMAGE_BUILD_VERSION}-${JIRA_TAG}",
     ]
     cache-from= ["type=registry,ref=${REGISTRY}/${REGISTRY_PROJECT}/hopsworks/hive:cache-${JIRA_TAG}"]
     cache-to = ["type=registry,ref=${REGISTRY}/${REGISTRY_PROJECT}/hopsworks/hive:cache-${JIRA_TAG},mode=max,image-manifest=true"]

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
   </modules>
 
   <properties>
-    <hive.version.shortname>3.0.0.10</hive.version.shortname>
+    <hive.version.shortname>3.0.0.13</hive.version.shortname>
     <image.build.version>v1</image.build.version>
 
     <!-- Build Properties -->

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
 
   <properties>
     <hive.version.shortname>3.0.0.10</hive.version.shortname>
+    <image.build.version>v1</image.build.version>
 
     <!-- Build Properties -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
… Maven version

Add image.build.version Maven property (default v1) that gets appended to Docker image tags. This allows rebuilding images for OS security patches without bumping the Hive Maven version.

Image tag format: <maven-version>-<build-version> (e.g., 3.0.0.13.15-v1)