### PR TITLE
[HWORKS-2988] Upgrade OS packages in the hive image

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -14,6 +14,8 @@ ARG USERID="1516"
 ARG HADOOP_GROUP_NAME="hadoop"
 ARG HADOOP_GROUP_ID="1234"
 
+RUN apt-get update && apt-get upgrade -y
+
 RUN groupadd -g ${HADOOP_GROUP_ID} ${HADOOP_GROUP_NAME} && \
     useradd -m --uid ${USERID} --gid ${HADOOP_GROUP_ID} ${USER}
 


### PR DESCRIPTION
## Why

The hive metastore image was skipped by the HWORKS-2988 fleet rollout: the census bucketed it as *no package layer*, because `dockerfiles/Dockerfile` has no `apt-get install` line to attach the upgrade to. That is true of the Dockerfile, but not of the image — it inherits `eclipse-temurin:8`'s Ubuntu userland and never upgrades it.

A fresh Harbor/Trivy scan (v0.68.2, 2026-08-04) of the shipped `docker.hops.works/hopsworks/hive:3.0.0.14.5-v1` — the tag pinned by hopsworks-helm on **both** `main` and `branch-5.0`, via `charts/hive/Chart.yaml` `appVersion` — reports **850 findings / 428 distinct CVEs**, of which:

| | Rows | Severity | Fix available |
|---|---|---|---|
| deb packages (apt can fix) | 197 | 3 H / 134 M / 60 L | **150** |
| Go binaries (apt cannot fix) | 24 | 12 H / 10 M / 2 unknown | — |
| bundled jars | 629 | **all 62 Criticals** / 330 H | 605 |

So this clears up to ~150 rows (~18% of the total), all Medium/Low plus 3 Highs.

## Scope — what this does *not* fix

**Zero Criticals.** All 62 live in bundled jars: jackson-databind at 2.4.0 / 2.9.4 / 2.9.10 accounts for 48 of them, jetty-server 9.3.x for 5, then singles in calcite-core 1.16.0, avro 1.8.2, zookeeper 3.4.7, netty 3.10.5, ivy 2.4.0, parquet-avro 1.11.0, spark-core_2.11 2.3.0, jackson-mapper-asl 1.9.13, bcprov-jdk18on 1.82. Those need dependency work, tracked separately.

## Placement

Its own layer, after the `ARG` block and ahead of everything that unpacks the hadoop/hive distributions, so later layers build on upgraded packages. Form matches `testconnector/Dockerfile` in docker-images, the existing standalone precedent from the fleet rollout (the other 10 files piggyback on an existing `apt-get install`).

Not tested by a build — the image is built by Jenkins, not by PR CI.

Companion PR for the release line: `branch-3.0.0.14` (clean `cherry-pick -x`), which is the branch that built the currently shipped tag (HEAD `2a66ae929b` = `3.0.0.14.5-v1-20260527-2a66ae929`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)