### PR TITLE
[HWORKS-2988] Upgrade OS packages in the hive image (branch-3.0.0.14)

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -14,6 +14,8 @@ ARG USERID="1516"
 ARG HADOOP_GROUP_NAME="hadoop"
 ARG HADOOP_GROUP_ID="1234"
 
+RUN apt-get update && apt-get upgrade -y
+
 RUN groupadd -g ${HADOOP_GROUP_ID} ${HADOOP_GROUP_NAME} && \
     useradd -m --uid ${USERID} --gid ${HADOOP_GROUP_ID} ${USER}
 


### PR DESCRIPTION
Clean `cherry-pick -x` of #114 onto `branch-3.0.0.14`.

This is the branch that matters for what we ship: its HEAD `2a66ae929b` is the commit in the currently shipped tag `3.0.0.14.5-v1-20260527-2a66ae929`, and hopsworks-helm pins `3.0.0.14.5-v1` on **both `main` and `branch-5.0`** (`charts/hive/Chart.yaml` `appVersion`), so one rebuilt image covers both lines.

## Why

The image was skipped by the HWORKS-2988 fleet rollout — the census bucketed it as *no package layer* since `dockerfiles/Dockerfile` has no `apt-get install` to attach to. But it inherits `eclipse-temurin:8`'s Ubuntu userland and never upgrades it. A fresh Harbor/Trivy scan of `3.0.0.14.5-v1` (v0.68.2, 2026-08-04) shows **850 findings / 428 distinct CVEs**, including **197 deb rows (3 H / 134 M / 60 L) with 150 fixes available** — what this recovers.

**No Criticals are affected**: all 62 are bundled jars, 48 of them jackson-databind 2.4.0/2.9.x. Separate work.

Note the only prior vulnerability commit in this repo, `[HES-221] Bump version to address vulnerabilities` (#109), landed on `branch-3.0.0.13` only and never reached this branch.

Not build-tested; the image is built by Jenkins, not PR CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[HES-221]: https://hopsworks.atlassian.net/browse/HES-221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ