### PR TITLE
Restore deprecated METASTOREURIS/METASTOREWAREHOUSE ConfVars aliases

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -5874,7 +5874,33 @@ public class HiveConf extends Configuration {
 
     HIVE_OTEL_RETRY_BACKOFF_MULTIPLIER("hive.otel.retry.backoff.multiplier", 5f,
         "The multiplier applied to the backoff interval for retries in the OTEL exporter."
-            + "This determines how much the backoff interval increases after each failed attempt, following an exponential backoff strategy.");
+            + "This determines how much the backoff interval increases after each failed attempt, following an exponential backoff strategy."),
+
+    /**
+     * Compatibility alias for the pre-HIVE-27925 spelling of {@link #METASTORE_URIS}.
+     * HIVE-27925 renamed the ConfVars constants in Hive 4.0.0 without leaving aliases,
+     * which breaks consumers compiled against Hive 3.x at link time with a
+     * NoSuchFieldError (notably Apache Iceberg's HiveCatalog and CachedClientPool).
+     * Declares the same varname and default as its counterpart, and is excluded from
+     * the generated hive-default.xml.template so it emits no duplicate property block.
+     *
+     * @deprecated Use {@link #METASTORE_URIS}.
+     */
+    @Deprecated
+    METASTOREURIS("hive.metastore.uris", "",
+        "Thrift URI for the remote metastore. Used by metastore client to connect to remote metastore.",
+        true),
+
+    /**
+     * Compatibility alias for the pre-HIVE-27925 spelling of {@link #METASTORE_WAREHOUSE}.
+     * See {@link #METASTOREURIS} for rationale.
+     *
+     * @deprecated Use {@link #METASTORE_WAREHOUSE}.
+     */
+    @Deprecated
+    METASTOREWAREHOUSE("hive.metastore.warehouse.dir", "/user/hive/warehouse",
+        "location of default database for the warehouse",
+        true);
 
     public final String varname;
     public final String altName;


### PR DESCRIPTION
Adds back the two pre-HIVE-27925 `HiveConf.ConfVars` spellings as deprecated aliases, so consumers compiled against Hive 3.x link against Hive 4.

### Why

[HIVE-27925](https://issues.apache.org/jira/browse/HIVE-27925) renamed the ConfVars constants in Hive 4.0.0 (`METASTOREURIS` -> `METASTORE_URIS`, `METASTOREWAREHOUSE` -> `METASTORE_WAREHOUSE`) with no compatibility aliases. It was filed purely as a readability improvement, but it breaks every downstream compiled against Hive 3.x at link time:

```
java.lang.NoSuchFieldError: METASTOREURIS
  at org.apache.iceberg.hive.CachedClientPool.extractKey(CachedClientPool.java:135)
  at org.apache.iceberg.hive.HiveCatalog.initialize(HiveCatalog.java:142)
```

Apache Iceberg is the case that affects us. `iceberg-spark-runtime` still references the old names and upstream has no Hive 4 support: apache/iceberg#10429 was closed not-planned and apache/iceberg#12721 closed unmerged. Iceberg pins `hive2 = strictly "2.3.10"`, which matches stock Spark's `hive.version`, so upstream users never hit this. We do, because our Spark distribution bundles Hive 4.1.0.

The practical effect today: **every Iceberg feature group fails on Spark 4.1**.

### The change

Two enum constants declaring the same varname and default as their counterparts:

- appended at the **end** of the enum, so no existing constant's `ordinal()` shifts
- constructed with `excluded=true`, so `GenHiveTemplate` emits no duplicate `<property>` into `hive-default.xml.template`
- marked `@Deprecated`, pointing at the new names

Note the enum constant name is all that changed upstream - the config property strings never did, and `MetastoreConf` still honours `hive.metastore.uris` / `hive.metastore.warehouse.dir` as `hiveName` aliases, read by every `getVar`/`getBoolVar`/... accessor. So an alias is fully effective, not a link-time-only shim.

### Safety of the duplicate varname

| site | behaviour with an identical-valued duplicate |
|---|---|
| `vars` / `reverseMap` | plain `HashMap.put` - overwrites, same key -> same value |
| `logVars` | one extra printed line |
| `getConfSystemProperties`, `applyDefaultNonNullConfVars` | idempotent |
| `HCatUtil` | keyed by enum name, distinct keys, same default |
| `HiveConnection` | keyed by varname, same value twice |

Hive itself never references the old spellings, and the codebase contains exactly **one** ConfVars identity comparison (`LogUtils`, on `HIVE_EXEC_LOG4J_FILE`), which is unrelated - so no reverse lookup can return the 'wrong' constant to code that compares by identity.

### Verification

With these aliases present, **stock unmodified** `iceberg-spark-runtime-4.1_2.13-1.11.0` links and initializes against Hive 4.1.0:

| | `METASTOREURIS` | `extractKey` |
|---|---|---|
| stock Hive 4.1 | absent | `NoSuchFieldError` |
| with aliases | present | OK |

### Known gap

Iceberg also calls `StructTypeInfo.getAllStructFieldNames` / `getAllStructFieldTypeInfos`, which changed return type from `ArrayList` to `List` in Hive 4. Aliases cannot address that (it is a signature change, not a constant). It is only reachable from Hive->Iceberg schema conversion, which the feature-group read/write paths do not exercise.