### PR TITLE
[HWORKS-2879] Exclude upstream Hadoop from orc-core, and unbreak the full build

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -77,7 +77,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-client-api</artifactId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/hops-jdbc/src/java/io/hops/hive/jdbc/HiveConnection.java
+++ b/hops-jdbc/src/java/io/hops/hive/jdbc/HiveConnection.java
@@ -21,7 +21,7 @@ package io.hops.hive.jdbc;
 import org.apache.hive.service.rpc.thrift.TSetClientInfoResp;
 
 import org.apache.hive.service.rpc.thrift.TSetClientInfoReq;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.common.auth.HiveAuthUtils;
 import io.hops.hive.jdbc.Utils.JdbcConnectionParams;
 import org.apache.hive.service.auth.HiveAuthConstants;

--- a/pom.xml
+++ b/pom.xml
@@ -692,7 +692,7 @@
         <exclusions>
           <exclusion>
             <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
+            <artifactId>*</artifactId>
           </exclusion>
           <exclusion>
             <groupId>io.hops.hive</groupId>

--- a/standalone-metastore/metastore-common/pom.xml
+++ b/standalone-metastore/metastore-common/pom.xml
@@ -56,7 +56,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-common</artifactId>
+          <artifactId>*</artifactId>
         </exclusion>
         <exclusion>
           <groupId>io.hops.hive</groupId>

--- a/standalone-metastore/metastore-server/pom.xml
+++ b/standalone-metastore/metastore-server/pom.xml
@@ -54,11 +54,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-client-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-common</artifactId>
+          <artifactId>*</artifactId>
         </exclusion>
         <exclusion>
           <groupId>io.hops.hive</groupId>


### PR DESCRIPTION
Two commits. The first fixes the hopsworks-ee outage; the second makes `branch-4.1` complete a full `mvn install` again.

---

# 1. Exclude upstream Hadoop from `orc-core`

Our `orc-core` exclusions name the Hadoop artifacts ORC *used to* pull, and disagree with each other:

| declaration | excluded before |
|---|---|
| `pom.xml` (dM), `standalone-metastore/metastore-common` | `hadoop-common` |
| `standalone-metastore/metastore-server` | `hadoop-client-api`, `hadoop-common` |
| `common` | `hadoop-client-api` |

ORC 2.x depends on neither of those alone:

```
org.apache.orc:orc-core:2.1.2
  org.apache.hadoop:hadoop-client-api      compile
  org.apache.hadoop:hadoop-client-runtime  runtime
```

**No declaration excludes `hadoop-client-runtime`**, so all four leak. The 3.0.0.14.x line had none of this — a `dependency:tree` over `hive-common`, `-exec`, `-serde`, `-service` and `-standalone-metastore` at 3.0.0.14.6 returns zero `org.apache.hadoop`, because it pulled no `orc-core` at all and reached Hadoop only via `hive-shims-common -> io.hops:hadoop-client`.

### What it broke

`hive-standalone-metastore-common` leaks both jars, which put two complete Hadoop client distributions in hopsworks-ee's Payara `domain1/lib`. Both carry `org.apache.hadoop.ipc.Client$Connection`; only the Hops one has the `instanceof HopsSSLSocketFactory` branch (6 refs vs 0), and `3.4.1` sorts first. When the vanilla one wins, `setupConnection` falls through to the no-arg `socketFactory.createSocket()`, which `HopsSSLSocketFactory` does not implement:

```
java.net.SocketException: Unconnected sockets not implemented
   at org.apache.hadoop.ipc.Client$Connection.setupConnection(Client.java:625)
```

156 occurrences in a single `hopsworks-instance` on hopsworks-helm CI run `33250561042` — 148 `AirflowDagReconciler` failing for every project, 4 project creation — failing end2end on both the plain-k8s and the ArgoCD install.

### The change

`org.apache.hadoop:*` on all four `orc-core` declarations. A wildcard rather than named artifacts, so it cannot go stale again the next time ORC changes which Hadoop artifact it depends on — which is how this happened.

### Safety

`jdeps` over `orc-core-2.1.2` finds 45 `org.apache.hadoop` references, 15 of them genuine Hadoop (`Configuration`, `FileSystem`, `Path`, `FSDataInputStream/OutputStream`, `FileStatus`, `FsPermission`, `FileRange`, `io.Text`, …). **All 15 are present in `io.hops:hadoop-common`**, which the metastore already declares directly — nothing HDFS-internal, the only area where the Hops fork diverges. `orc-core`, `orc-shims` and `orc-format` all still resolve.

```
standalone-metastore/metastore-common    0 org.apache.hadoop     <- what hopsworks-ee consumes
standalone-metastore/metastore-server    0 org.apache.hadoop
```

---

# 2. Use `commons-lang3` in the Hops JDBC driver

Independently of the above, a full `mvn install` fails at the last module:

```
[56/56] HopsHive JDBC
Rule 1: RestrictImports failed
Banned imports detected:
  Reason: Do not use commons-lang
    in file: /io/hops/hive/jdbc/HiveConnection.java
      org.apache.commons.lang.StringUtils (Line: 24)
```

Hive 4.1 migrated `commons-lang` -> `commons-lang3` and added an enforcer rule to keep it that way. `hops-jdbc` is a Hops-only module whose `HiveConnection.java` was carried over from `branch-3.0.0.14` in `52a0373ede` — the only commit that has ever touched `hops-jdbc/` — without that migration, so the rule now rejects it.

Upstream's own copy already uses lang3 for the same calls (`jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java:83`), so this aligns the Hops copy with the file it was forked from.

**Safe:** the file uses `StringUtils` exactly once — `isNotBlank(strRetries)` at line 229, where `strRetries` is a `String` from `sessConfMap.get()`. lang3's `isNotBlank` takes a `CharSequence`, so a `String` still binds and the semantics are identical. `commons-lang3:3.12.0` is already on `hops-jdbc`'s compile classpath. This is the only `import org.apache.commons.lang.` left anywhere in the fork.

---

## Verification

`mvn clean install -DskipTests` over the **whole 56-module reactor**:

```
modules SUCCESS:            56
FAILURE or SKIPPED:          0
banned-import violations:    0
BUILD SUCCESS
```

Before commit 2 the same run failed at 56/56. `mvn clean install -pl ql -am` was also run against pristine `branch-4.1` and against this branch back to back — both `BUILD SUCCESS`.

## Scope

Deliberately limited to the ORC path plus the build breakage.

`hive-common` and `hive-exec` still resolve upstream Hadoop through `tez-*`, `atlas-intg` and `hbase-common:2.5.6-hadoop3`. Untidy but not currently harmful: `packaging/src/main/assembly/bin.xml` excludes `org.apache.hadoop:*` from the distribution (lines 43 and 104), so no upstream jar reaches the Hive tarball or image. Only `domain1/lib` in hopsworks-ee, which has no such filter, was exposed — and that is fixed here.

Two findings worth their own tickets rather than widening this PR:

1. **`ql` compiles against upstream `NetUtils`.** Excluding upstream Hadoop from `ql` fails to compile at `ProactiveEviction.java:123` and `LlapCacheResourceProcessor.java:158`, because Hops' `NetUtils.getDefaultSocketFactory(Configuration)` declares `throws SSLCertificateException` and vanilla's does not. No runtime impact — checked exceptions are not part of the JVM descriptor, and `SSLCertificateException extends IOException` so existing handlers catch it. Those two are the only call sites in the fork missing the treatment the other nine already have (`throws IOException`, or wrap as `RuntimeException("Failed to create socket factory", e)`).
2. **`packaging` resolves `org.apache.hadoop:hadoop-client:2.6.5`** and 13 siblings on pristine `branch-4.1` — a fourth Hadoop line, masked by the assembly filter.

## Note for local builds

Hive's pom declares repository id `hops-releases` (`nexus.hops.works/repository/hops-artifacts`) while credentials are commonly stored under id `HopsEE` for the same URL, so a cold local repo 401s on `io.hops.hive:hive-common:jar:tests`. Adding a `<server>` with id `hops-releases` fixes it.

logicalclocks/hopsworks-ee#3269 applies the orc exclusion downstream as an immediate unblock; it can be reverted once a Hive build carrying this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLodKqDuSBE4Fdu4eh1oDQ